### PR TITLE
Changed deprecated `compile` to `implementation` in `build.gradle`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.apache.commons:commons-collections4:4.4'
+    implementation 'org.apache.commons:commons-collections4:4.4'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
 }


### PR DESCRIPTION
Fixes #1.

Changed deprecated `compile` dependency configuration to `implementation` to fix build error encountered when using Gradle 7.

See: [Could not find method compile() for arguments Gradle
](https://stackoverflow.com/questions/23796404/could-not-find-method-compile-for-arguments-gradle):

> Note that the `compile`, `runtime`, `testCompile`, and `testRuntime` configurations introduced by the Java plugin have been deprecated since [Gradle 4.10](https://docs.gradle.org/4.10/userguide/java_plugin.html#sec:java_plugin_and_dependency_management) ([Aug 27, 2018](https://gradle.org/releases/)), and were finally removed in [Gradle 7.0](https://docs.gradle.org/7.0/userguide/java_library_plugin.html#sec:java_library_configurations_graph) ([Apr 9, 2021](https://gradle.org/releases/)).
> 
> The aforementioned configurations should be replaced by `implementation`, `runtimeOnly`, `testImplementation`, and `testRuntimeOnly`, respectively.

Tested with:
```
Gradle 7.0
JVM:          11.0.7 (Oracle Corporation 11.0.7+8-LTS)
OS:           Mac OS X 10.16 x86_64
```
